### PR TITLE
Changes for multi tenant fixes for EP app: virtual idp collection

### DIFF
--- a/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
+++ b/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
@@ -71,7 +71,8 @@ namespace Kentor.AuthServices.Owin
             }
             else
             {
-                var redirectUrl = Options.SPOptions.ReturnUrl;
+                var redirectUrl = Options.Notifications.GetReturnUrl(httpRequestData.StoredRequestState) ??
+                    Options.SPOptions.ReturnUrl;
 
                 if (redirectUrl == null)
                 {

--- a/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationOptions.cs
+++ b/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationOptions.cs
@@ -62,7 +62,7 @@ namespace Kentor.AuthServices.Owin
         /// <summary>
         /// Available identity providers.
         /// </summary>
-        public IdentityProviderDictionary IdentityProviders
+        public virtual IdentityProviderDictionary IdentityProviders
         {
             get
             {

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
@@ -16,6 +16,7 @@ namespace Kentor.AuthServices.Configuration
         /// <summary>
         /// Ctor, setting all callbacks to do-nothing versions.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         public KentorAuthServicesNotifications()
         {
             AuthenticationRequestCreated = (request, provider, dictionary) => { };
@@ -31,6 +32,7 @@ namespace Kentor.AuthServices.Configuration
             MetadataCreated = (md, urls) => { };
             MetadataCommandResultCreated = cr => { };
             ValidateAbsoluteReturnUrl = url => false;
+            GetReturnUrl = storedRequestState => null;
         }
 
         /// <summary>
@@ -148,5 +150,12 @@ namespace Kentor.AuthServices.Configuration
         /// When false is returned, the SignIn and Logout commands will throw an <see cref="InvalidOperationException"/>.
         /// </summary>
         public Func<string, bool> ValidateAbsoluteReturnUrl { get; set; }
+
+        /// <summary>
+        /// Notification called when a command is about to get the default return url to redirect the client to.
+        /// Return a non-null Uri if you need to override this per request.
+        /// Otherwise it will fall back to the normal logic that checks the SPOptions.ReturnUrl setting.
+        /// </summary>
+        public Func<StoredRequestState, Uri> GetReturnUrl { get; set; }
     }
 }


### PR DESCRIPTION
Изменения:
- добавлена GetReturnUrl нотификация для получения специфического для текущего аккаунта ReturnUrl при Identity provider initiated SSO.
- IdentityProviders свойство в OWIN options сделано виртуальным, чтобы была возможность его переписать на per request опцию. Так как коллекция динамическая для каждого аккаунта, не может быть проинициализирована при старте приложения.